### PR TITLE
Install and Instructions Fix

### DIFF
--- a/builddoc
+++ b/builddoc
@@ -50,7 +50,7 @@ build() {
 
 make_markdown() {
     cd "$BUILD_DIRECTORY"/target
-    "$PROG_DIR"/modules/markdown-pp/markdown-pp.py "$BUILD_DIRECTORY"/target/"$INDEX_FILE" "$BUILD_DIRECTORY"/"$DOC_MARKDOWN"
+    markdown-pp -o "$BUILD_DIRECTORY"/"$DOC_MARKDOWN" "$BUILD_DIRECTORY"/target/"$INDEX_FILE"
     cd "$RUN_DIR"
 }
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,32 +1,36 @@
 # Installation Instructions
 
-Currently we have instructions for installing on the Ubuntu operating-system.
+Currently we have instructions for installing on Debian-based operating systems such as Ubuntu.
 
  * Install Prerequisites
-   * For Python 2:
-
-```
-sudo apt-get install git pandoc python-setuptools python-pip
-sudo pip install MarkdownPP
-```
-
-   * For Python 3:
-   
-```
-sudo apt-get install git pandoc python3-setuptools python3-pip
-sudo pip install MarkdownPP
-```   
+	
+	* To check Python version, try the following commands. Commands may differ based on Python installation
+	```
+	py --version
+	python --version
+	python3 --version
+	```
+	* For Python 2
+	```
+	sudo apt-get install git pandoc python-setuptools python-pip
+	sudo pip install MarkdownPP
+	```
+	* For Python 3
+	```
+	sudo apt-get install git pandoc python3-setuptools python3-pip
+	sudo pip install MarkdownPP
+	``` 
 
  * Download the Documentation Builder
 
-```
-git clone --recursive https://github.com/OpenInternet/Documentation-Builder.git
-```
+ ```
+ git clone --recursive https://github.com/OpenInternet/Documentation-Builder.git
+ ```
 
   * Download and install [wkhtmltopdf](http://wkhtmltopdf.org/downloads.html) with patched qt (installing from package repositories does not enable all required features)
 
-```
-wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
-tar vxf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz 
-cp wkhtmltox/bin/wk* /usr/local/bin/
-```
+ ```
+ wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
+ tar vxf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz 
+ cp wkhtmltox/bin/wk* /usr/local/bin/
+ ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -3,10 +3,19 @@
 Currently we have instructions for installing on the Ubuntu operating-system.
 
  * Install Prerequisites
+   * For Python 2:
 
 ```
-sudo apt-get install git pandoc python-setuptools
+sudo apt-get install git pandoc python-setuptools python-pip
+sudo pip install MarkdownPP
 ```
+
+   * For Python 3:
+   
+```
+sudo apt-get install git pandoc python3-setuptools python3-pip
+sudo pip install MarkdownPP
+```   
 
  * Download the Documentation Builder
 


### PR DESCRIPTION
Fixes install instructions for builddoc, making download of markdown-pp explicit.  Fixes builddoc bash script, using this explicitly downloaded version of markdown-pp instead of the outdated, forked and cloned copy that is within Documentation Builder.